### PR TITLE
Update brightness-control

### DIFF
--- a/.config/openbox/scripts/brightness-control
+++ b/.config/openbox/scripts/brightness-control
@@ -4,7 +4,7 @@ msgId="991001"
 
 if [ "$1" = "up" ]; then
     xbacklight -inc 5
-elif [ "$1" = "down"]; then
+elif [ "$1" = "down" ]; then
     xbacklight -dec 5
 fi
 


### PR DESCRIPTION
Line 7 of the brightness script is missing a space before the right square bracket making the brackets unmatched when run in an Openbox environment.